### PR TITLE
lib now throws an error if AMQP connection fails

### DIFF
--- a/src/services/message-queue.service.js
+++ b/src/services/message-queue.service.js
@@ -30,6 +30,9 @@ export class MessageQueue extends EventEmitter {
     return new Promise((resolve) => {
       const connection = amqp.createConnection(this._connectionConfig, {reconnect: false});
       connection.on('ready', () => resolve(connection));
+      connection.on('error', err => {
+        throw err;
+      });
     });
   }
 


### PR DESCRIPTION
Previously the lib failed silently if the underlying AMQP connection experienced any errors during queue subscription process. Now, it will surface those errors by throwing them itself.